### PR TITLE
Launch firmware 1.2 update

### DIFF
--- a/bluetooth.md
+++ b/bluetooth.md
@@ -19,3 +19,9 @@ Status notifications characteristic for the Launch is
 ```
 88f80582-0000-01e6-aace-0002a5d5c51b
 ```
+
+The write characteristic to specify the type of commands is (Firmware 1.2+)
+
+```
+88f80583-0000-01e6-aace-0002a5d5c51b
+```

--- a/protocol.md
+++ b/protocol.md
@@ -16,6 +16,8 @@ The command protocol for the launch consists of two byte packets.
   
 Invalid inputs are ignored.
 
+Since firmware 1.2 it is required to send a 0 byte to the commands characteristic before sending these commands.
+
 ## Buttons
 
 Status of buttons is read via notifications sent by the Status

--- a/protocol.md
+++ b/protocol.md
@@ -16,7 +16,7 @@ The command protocol for the launch consists of two byte packets.
   
 Invalid inputs are ignored.
 
-Since firmware 1.2 it is required to send a 0 byte to the commands characteristic before sending these commands.
+Since firmware 1.2 it is required to send a 0x00 byte to the commands characteristic before sending these commands.
 
 ## Buttons
 


### PR DESCRIPTION
Since the 1.2 firmware the device needs a 0x00 byte sent to the command characteristic before sending device instructions. Without it the device won't accept all values and move randomly every few commands.